### PR TITLE
feat: Fetch single movie's data in SingleMovieContainer

### DIFF
--- a/src/ApiCall.js
+++ b/src/ApiCall.js
@@ -1,5 +1,7 @@
-const getMovieData =(data) => {
-  return fetch("https://rancid-tomatillos.herokuapp.com/api/v2/movies")
+const getMovieData = id => {
+  let path;
+  id ? path = id : path = ''
+  return fetch(`https://rancid-tomatillos.herokuapp.com/api/v2/movies/${path}`)
   .then((response) => {
     if(!response.ok){
       throw new Error( `${response.status}:${response.statusText}`)

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,10 +1,10 @@
 import React, {Component} from 'react';
+import getMovieData from '../../ApiCall';
 import Header from '../Header/Header';
 import MoviesContainer from '../MoviesContainer/MoviesContainer';
-import movieMockData from '../../movieData/movieData';
+// import movieMockData from '../../movieData/movieData';
 import './App.css';
 import SingleMovieContainer from '../SingleMovieContainer/SingleMovieContainer';
-import getMovieData from '../../ApiCall';
 
 class App extends Component {
   constructor() {
@@ -16,10 +16,7 @@ class App extends Component {
   }
   
   componentDidMount() {
-    getMovieData().then(data => {
-      this.setState({movieData: data})
-    })
-    
+    getMovieData().then(data => this.setState({movieData: data}));
     // this.setState({ movieData: movieMockData });
   }
 
@@ -38,7 +35,7 @@ class App extends Component {
           selectMovie={this.selectMovie}
         /> :
         /*<p>Loading...</p>*/ null}
-        {this.state.selectedMovieId && <SingleMovieContainer />}
+        {this.state.selectedMovieId && <SingleMovieContainer movieId={this.state.selectedMovieId}/>}
       </main>
     );
   }

--- a/src/components/SingleMovieContainer/SingleMovieContainer.js
+++ b/src/components/SingleMovieContainer/SingleMovieContainer.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
-import singleMockData1 from '../../singleMovieData/singleMovie1';
-import singleMockData2 from '../../singleMovieData/singleMovie2';
+import getMovieData from '../../ApiCall';
+// import singleMockData1 from '../../singleMovieData/singleMovie1';
+// import singleMockData2 from '../../singleMovieData/singleMovie2';
 import MovieDetailsSection from '../MovieDetailsSection/MovieDetailsSection';
 import SingleMovieBanner from '../SingleMovieBanner/SingleMovieBanner';
 
@@ -14,7 +15,8 @@ class SingleMovieContainer extends Component {
   }
 
   componentDidMount = () => {
-    this.setState({ singleMovieData: singleMockData1 });
+    getMovieData(this.props.movieId).then(data => this.setState({ singleMovieData: data }))
+    // this.setState({ singleMovieData: singleMockData1 });
   }
 
   render() {


### PR DESCRIPTION
This modifies `getMovieData` to accept an optional parameter called `id`. If it is present, it appends that ID to the end of the URL path in the fetch request. In `SingleMovieContainer.js`, the `componentDidMount` method now uses `getMovieData` and passes in the id of the movie, which is passed down from `App.js` as the `moviId` prop.

The app now successfully fetches a single movie's data and uses it to render `SingleMovieBanner` and `MovieDetailsSection` with the appropriate movie's data based on which poster the user clicks.