### PR TITLE
Test/home button

### DIFF
--- a/cypress/e2e/home_button_spec.cy.js
+++ b/cypress/e2e/home_button_spec.cy.js
@@ -1,0 +1,35 @@
+describe('Home Button', () => {
+  beforeEach('Go to movie details', () => {
+    cy.visit('http://localhost:3000')
+    cy.loadPage()
+    cy.get('.movie-card').contains('h3', 'Black Adam').click()
+    cy.loadSingleMovie()
+  })
+  
+  it('should show a home button', () => {
+    cy.get('.button-home').contains('button', 'Home')
+  })
+
+  it('should go back to the home page when clicked', () => {
+    cy.get('.button-home').click();
+
+    cy.url().should('eq', 'http://localhost:3000/');
+
+    cy.get('.header').get('img')
+      .should('have.attr', 'src', '/static/media/tomatillo.c57a8444c30f4e09f57a.png')
+      .should('be.visible')
+      .get('.header').contains('h1', 'Rancid Tomatillos');
+    
+    cy.get('.movie-card').should('have.length', 5);
+    
+    cy.get('.movie-card:first()').find('img').should('have.attr', 'src', 'https://image.tmdb.org/t/p/original//pFlaoHTZeyNkG83vxsAJiGzfSsa.jpg')
+      .get('.movie-card:first()').contains('h3', 'Black Adam')
+      .get('.movie-card:first()').find('p:first()').contains('4')
+      .get('.movie-card:first()').find('p:last()').contains('2022-10-19');
+
+    cy.get('.movie-card:last()').find('img').should('have.attr', 'src', 'https://image.tmdb.org/t/p/original//pUPwTbnAqfm95BZjNBnMMf39ChT.jpg')
+      .get('.movie-card:last()').contains('h3', 'The Minute You Wake Up Dead')
+      .get('.movie-card:last()').find('p:first()').contains('5')
+      .get('.movie-card:last()').find('p:last()').contains('2022-11-04');
+  });
+})

--- a/cypress/e2e/main_spec.cy.js
+++ b/cypress/e2e/main_spec.cy.js
@@ -1,24 +1,34 @@
 
 
-describe('Rancid Tomatillos', () => {
+describe('Main Page', () => {
   beforeEach(() => {
     cy.visit('http://localhost:3000')
     cy.loadPage()
 
-      
   });
   it('Should show the main page with a header', () => {
-    cy.get('.header').find('img');
-    cy.get('.header').contains('h1', 'Rancid Tomatillos');
+    cy.url().should('eq', 'http://localhost:3000/');
+
+    cy.get('.header').get('img')
+      .should('have.attr', 'src', '/static/media/tomatillo.c57a8444c30f4e09f57a.png')
+      .should('be.visible')
+      .get('.header').contains('h1', 'Rancid Tomatillos');
   });
 
   it('Should show thumbnails of all the movies', () => {
-    cy.get('.movie-card').should('have.length', 5)
-    cy.get('.movie-card').find('img');
-    cy.get('.movie-card').find('h3');
-    cy.get('.movie-card').find('p');
+    cy.get('.movie-card').should('have.length', 5);
+    
+    cy.get('.movie-card:first()').find('img').should('have.attr', 'src', 'https://image.tmdb.org/t/p/original//pFlaoHTZeyNkG83vxsAJiGzfSsa.jpg')
+      .get('.movie-card:first()').contains('h3', 'Black Adam')
+      .get('.movie-card:first()').find('p:first()').contains('4')
+      .get('.movie-card:first()').find('p:last()').contains('2022-10-19');
+
+    cy.get('.movie-card:last()').find('img').should('have.attr', 'src', 'https://image.tmdb.org/t/p/original//pUPwTbnAqfm95BZjNBnMMf39ChT.jpg')
+      .get('.movie-card:last()').contains('h3', 'The Minute You Wake Up Dead')
+      .get('.movie-card:last()').find('p:first()').contains('5')
+      .get('.movie-card:last()').find('p:last()').contains('2022-11-04');
   });
-  });
+});
 
 
 


### PR DESCRIPTION
Description
This adds testing for the user story to get back to the home page. Stubs are used to mimic the page loading for the first time and the user clicking a movie to get to the movie details page. Other test files cover the user paths for arriving at the main page and navigating to the movie details, so this test only checks for the home button. When the button is clicked, the the test then checks the url and the contents of the page to make sure the user has actually arrived back to the main page.

This also updates the `main_spec.cy.js` test file to use more specific tests now that we have some more tools under our belt.

Related Issue(s)
closes #41

Changes
Adds new `home_button_spec.cy.js` and updates `main_spec.cy.js`

Testing
Tests to make sure the "Home" button is present on the movie details page.
Tests to make sure the url changes back to `http://localhost:3000/` when the button is clicked.
Tests to make sure the home page elements are all present.