### PR TITLE
Feature: Add sad path testing to main_spec

### DIFF
--- a/cypress/e2e/main_spec.cy.js
+++ b/cypress/e2e/main_spec.cy.js
@@ -28,6 +28,17 @@ describe('Main Page', () => {
       .get('.movie-card:last()').find('p:first()').contains('5')
       .get('.movie-card:last()').find('p:last()').contains('2022-11-04');
   });
+
+  it('Should handle an error when failing to fetch.', () => {
+  cy.intercept('GET','https://rancid-tomatillos.herokuapp.com/api/v2/movies', {
+    statusCode: 404
+  })
+  })
+
+  it('Should send the user a message when the fetch failed', () => {
+    cy.contains('Not Found!')
+  })
+
 });
 
 


### PR DESCRIPTION
## Description
This adds a sad path for the main page when the status code is a 404

## Related Issue(s)
#52 

## Changes
Adds new file main_spec.cy.js

## Testing

- Tests to make sure the user will get a message when they get a 404 status code.
- Tests to make sure home page elements aren't present