### PR TITLE
feat: Add sad path testing for failed single movie fetch

### DIFF
--- a/cypress/e2e/details_spec.cy.js
+++ b/cypress/e2e/details_spec.cy.js
@@ -6,18 +6,18 @@ describe('Rancid Tomatillos Details Page', () => {
     cy.loadSingleMovie()
   });
 
-     it('Should show the details page with the header', () => {
+  it('Should show the details page with the header', () => {
      cy.get('.header').find('img');
      cy.get('.header').contains('h1', 'Rancid Tomatillos');
-   });
+  });
 
-   it('Should have a banner', () => {
+  it('Should have a banner', () => {
     cy.get('img')
     .should( 'have.attr', 'src', '/static/media/tomatillo.c57a8444c30f4e09f57a.png')
     .should('be.visible')
-   })
+  });
    
-   it('Should have details', () => {
+  it('Should have details', () => {
     cy.get('.movie-details').contains('h1', 'Black Adam', 'h2', 'The world needed a hero. It got Black Adam.')
     cy.get('.movie-overview')
     .find('p:first()').contains('125')
@@ -36,5 +36,22 @@ describe('Rancid Tomatillos Details Page', () => {
     cy.get('.movie-overview')
     .find('p:eq(5)').contains('4')
     cy.get('p').contains('Nearly 5,000 years after he was bestowed with the almighty powers of the Egyptian gods—and imprisoned just as quickly—Black Adam is freed from his earthly tomb, ready to unleash his unique form of justice on the modern world.')
-   })
-  })
+  });
+});
+
+describe('Rancid Tomatillos Details Page Sad Path', () => {
+  it('Should show an error message with failed fetch with button to go home', () => {
+    cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/436270', {
+      statusCode: 404,
+    });
+
+    cy.visit('http://localhost:3000')
+    .loadPage()
+    .get('.movie-card').contains('h3', 'Black Adam').click()
+    .get('p').contains('Something went wrong when loading the movie. Click Home to select another movie.')
+    .get('button').contains('Home').click()
+    .get('.movie-card').should('have.length', 5)
+    .get('.movie-card:first()').contains('h3', 'Black Adam')
+    .get('.movie-card:last()').contains('h3', 'The Minute You Wake Up Dead')
+  });
+});


### PR DESCRIPTION
### Description
This tests the sad path for if the user clicks a single movie and the fetch request fails. An error message appears, instructing the user to click the Home button.

### Related Issue(s)
closes #52 

### Changes
Updates `details_spec.cy.js`

### Testing
Tests failed fetch request when user clicks a single movie.
Tests to make sure the home button and message are both present.
Tests to make sure the user returns to the home screen when the button is clicked.